### PR TITLE
Fix macOS build by using standard STRIP_LIBS variable

### DIFF
--- a/src/Makevars
+++ b/src/Makevars
@@ -6,6 +6,6 @@ PKG_CFLAGS = -I.
 OBJECTS = prostata.o prostata-init.o utils.o
 
 strippedLib: $(SHLIB)
-	if test -e "/usr/bin/strip"; then /usr/bin/strip --strip-debug $(SHLIB); fi
+	$(STRIP_LIBS)
 
 .phony: strippedLib


### PR DESCRIPTION
The hardcoded `strip --strip-debug` command fails on non-GNU systems like macOS, which use a different syntax. The version of strip included with Apple's Command Line Tools doesn't recognize the --strip-debug option.

This commit replaces the custom command with the R-provided `$(STRIP_LIBS)` variable, allowing the build system to use the platform-specific command.